### PR TITLE
Update .dockstore.yml to include Hello.cwl

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -60,7 +60,7 @@ workflows:
      testParameterFiles:
        - /cwl-training/exercise3/hello_examples/HelloGoodbye.json
      name: HelloGoodbye_cwl
-     - subclass: CWL
+   - subclass: CWL
      primaryDescriptorPath: cwl-training/exercise1/hello.cwl
      testParameterFiles:
        - cwl-training/exercise1/hello.json

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -60,6 +60,11 @@ workflows:
      testParameterFiles:
        - /cwl-training/exercise3/hello_examples/HelloGoodbye.json
      name: HelloGoodbye_cwl
+     - subclass: CWL
+     primaryDescriptorPath: cwl-training/exercise1/hello.cwl
+     testParameterFiles:
+         - cwl-training/exercise1/hello.json
+     name: Hello_cwl
    - subclass: NFL
      primaryDescriptorPath: /nextflow-training/exercise1/solution/nextflow.config
      name: HelloWorld_nextflow

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -63,7 +63,7 @@ workflows:
      - subclass: CWL
      primaryDescriptorPath: cwl-training/exercise1/hello.cwl
      testParameterFiles:
-         - cwl-training/exercise1/hello.json
+       - cwl-training/exercise1/hello.json
      name: Hello_cwl
    - subclass: NFL
      primaryDescriptorPath: /nextflow-training/exercise1/solution/nextflow.config


### PR DESCRIPTION
Would like to include a Hello workflow WDL as well as CWL example in Dockstore's first blog post. The WDL example already exists on Dockstore. Including the CWL example in the .dockstore.yml for it to be available as well.