### PR TITLE
Publish HelloWorld workflow in .dockstore.yml

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -5,6 +5,7 @@ workflows:
      testParameterFiles:
          - /wdl-training/exercise1/hello.json
      name: HelloWorld
+     publish: true
    - subclass: WDL
      primaryDescriptorPath: /wdl-training/exercise2/solution2/metrics.wdl
      testParameterFiles:


### PR DESCRIPTION
This PR adds the `publish` flag to the `.dockstore.yml` entry for the `HelloWorld` workflow, to help keep it published, since it is linked to from the Dockstore home page.